### PR TITLE
feat: sort by Q1 and Q3

### DIFF
--- a/src/en.json
+++ b/src/en.json
@@ -11,6 +11,8 @@
   "meanDesc": "(alternate middle, good for small samples)",
   "upperDesc": "(reasonable ceiling)",
   "lowerDesc": "(reasonable floor)",
+  "Q1Desc": "(lowest in top 75%)",
+  "Q3Desc": "(lowest in top 25%)",
   "maxDesc": "(the best!)",
   "startDate": "Start Date",
   "endDate": "End Date",

--- a/src/loa-logs.md
+++ b/src/loa-logs.md
@@ -126,6 +126,8 @@ const sortSelect = Inputs.select(
     ["Mean (alternate middle, good for small samples)", "Mean"],
     ["Upper (reasonable ceiling)", "Upper"],
     ["Lower (reasonable floor)", "Lower"],
+    ["Q3 (lowest in top 25%)", "Q3"],
+    ["Q1 (lowest in top 75%)", "Q1"],
     ["Max (the best!)", "Max"],
   ]),
   {


### PR DESCRIPTION
sort data by Q1 and Q3 like https://kennethnyu.github.io/overview

example: (the description might need to be changed in the list tho)

![image](https://github.com/user-attachments/assets/d8cd2c0c-8b57-4f46-82d4-dab9260f9042)

![image](https://github.com/user-attachments/assets/9c11a12c-b0c1-43df-9552-5c17186e3341)

i'm not familiar with d3 and observablehq framework but the logic looks okay